### PR TITLE
FIX: url 구조 변경

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,44 +20,45 @@ class Job(Document):
 
 
 @api.route('/api/v1/jobs')
-class JobCreatView(Resource):
+class JobCreatUpdateDeleteView(Resource):
     """
+    작성자: 윤상민
+
     [POST] Create Job
+    [PUT] Update Job
+    [DELETE] Delete Job
+    url의 pk를 사용하지 않고 입력값의 unique한 job_id로 자료를 컨트롤하기 때문에 CUD url을 한 곳에 두었습니다.
     """
     def post(self):
         data = request.get_json()
         job_id = data['job_id']
+        job = Job.objects(job_id=job_id).first()
+        job_last = Job.objects.order_by('-job_id').first()
+        if job is not None:
+            return Response(f"job_id={job_id} is exist. {job_last['job_id']+1} or higher is recommended", status=400)
         try:
             Job(**data).save()
         except:
-            # 몽고 ORM에서 뿜뿜하는 Validation조건을 아래에서 Raise할 수 있으면 좋겠음. 
-            return Response("입력조건 에러", status=400)
+            return Response("Bad Request", status=400)
         return Response(f"job_id={job_id}의 데이터가 생성되었습니다.", status=201)
 
-
-@api.route('/api/v1/jobs/<int:pk>')
-class JobUpdateDeleteView(Resource):
-    """
-    [PUT] Update Job
-    [DELETE] Delete Job
-    """
     def put(self, pk):
         data = request.get_json()
         job_id = data['job_id']
         job = Job.objects(job_id=job_id).first()
         if job is None:
-            return Response(f"job_id={job_id}에 해당하는 job이 없습니다.", status=400)
+            return Response(f"Bad Request. job_id={job_id} Not Found", status=404)
         job.update(**data)
-        return Response(f"job_id={job_id}가 업데이트되었습니다.", status=200)
+        return Response(f"job_id={job_id} Updated", status=200)
 
     def delete(self, pk):
         data = request.get_json()
         job_id = data['job_id']
         job = Job.objects(job_id=job_id).first()
         if job is None:
-            return Response(f"job_id={job_id}에 해당하는 job이 없습니다.", status=400)
+            return Response(f"Bad Request. job_id={job_id} Not Found", status=404)
         job.delete()
-        return Response(f"job_id={job_id}데이터 삭제 완료.")
+        return Response(f"job_id={job_id} Deleted", status=200)
         
 
 if __name__ == "__main__":


### PR DESCRIPTION
## :: 최근 작업 주제
- [ ] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
- 필요없는 url 제거

<br />

## :: 구현 사항 설명
- 기존 url은 Create와 Update/Delete를 url로 나누었습니다. 하지만 이는 url에서 <int:pk>와 같이 url의 내용을 직접 사용할 때 필요합니다. 하지만 MongoDB를 사용하는 지금과 같은 경우에는 입력하는 내부 job_id가 unique하여 pk로 작동하여서 url을 굳이 나눌 필요가 없다고 생각하였습니다. 
- task_run 작업하는데 영향이 있을 것으로 예상되어 풀리퀘를 일찍 요청합니다.



<br />

## :: ISSUE


<br />