### PR TITLE
FEAT: task list에 대한 DAG 알고리즘 적용

### DIFF
--- a/resources/errors.py
+++ b/resources/errors.py
@@ -1,5 +1,3 @@
-#~/movie-bag/resources/errors.py
-
 class InternalServerError(Exception):
     pass
 

--- a/resources/views.py
+++ b/resources/views.py
@@ -97,6 +97,8 @@ class JobTaskView(Resource):
             executor = JobExecutor()
             executor.run(job)
             return Response(f"job_id={pk} run task Success", status=200)
+        except ValueError as e:
+            return Response(f"message: {e}", status=400)
         except DoesNotExist:
             raise JobNotExistsError
         except Exception as e:

--- a/utils/executors.py
+++ b/utils/executors.py
@@ -1,18 +1,20 @@
 import json
 import pandas as pd
+import collections
+from utils.topology_sort import topology_sort
 
 class JobExecutor:
     def run(self, job_info):
 
-        task_list = job_info['task_list']
+        task_list= job_info['task_list']
         
+        task_queue = collections.deque(topology_sort(task_list))
         task_excutor = TaskExecutor()
 
-        for task in task_list.keys():
-            # WRAN
-            print("Run Task:", task)
-            task_fucntion = getattr(task_excutor, task.lower())
-            task_fucntion(job_info)
+        while task_queue:
+            task = task_queue.popleft()
+            task_func = getattr(task_excutor, task.lower())
+            task_func(job_info)
 
 
 class TaskExecutor:

--- a/utils/topology_sort.py
+++ b/utils/topology_sort.py
@@ -1,0 +1,58 @@
+import collections
+from typing import Dict, List
+
+def _check_double_edge(g):
+    for u in g:
+        v_counter = collections.Counter(g[u])
+        if len(v_counter) == 0:
+            continue
+        v, n = v_counter.most_common(1)[0]
+        if n > 1:
+            raise ValueError(f"There should not be more than one process going from {u} to {v}.")
+
+def _check_one_destination(g):
+    end_cnt = 0
+    for u in g:
+        if len(g[u]) == 0:
+            end_cnt += 1
+    if end_cnt > 1:
+        raise ValueError("There should not be more than one final destination.")
+
+def _get_parents_size(g):
+    parents_size = {k: 0 for k in g.keys()}
+    for u in g:
+        for v in g[u]:
+            parents_size[v] += 1
+    return parents_size
+
+def _topology_sort(g, p) -> List[str]:
+    """
+    위상 정렬
+    동시에 사이클도 판단한다.
+    """
+    q = collections.deque()
+    n = len(list(g.keys()))
+
+    for k in g:
+        if p[k] == 0:
+            q.appendleft(k)
+
+    sorted_data = []
+    while q:
+        u = q.pop()
+        sorted_data.append(u)
+
+        for v in g[u]:
+            p[v] -= 1
+            if p[v] == 0:
+                q.appendleft(v)
+    if len(sorted_data) < n:
+        raise ValueError("A cycle has been detected.")
+    return sorted_data
+
+def topology_sort(g: Dict[str, List[str]]):
+    _check_double_edge(g)
+    _check_one_destination(g)
+    parents_size = _get_parents_size(g)
+    return _topology_sort(g, parents_size)
+


### PR DESCRIPTION
## :: 최근 작업 주제
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
- `task_list`에 대한 DAG 알고리즘 적용

<br />

## :: 구현 사항 설명

### task_list가 사이클이 있는 경우
```json
"task_list" : {
    "read" : ["drop"], 
    "drop" : ["write"], 
    "write" : ["read"]
}
```

- Server 응답
```json
{
    "message": "A cycle has been detected."
    "status": 400
}
```

---

### 출발지에서 목적지로 가는 간선이 두개 이상인 경우
```json
"task_list" : {
    "read" : ["drop"], 
    "drop" : ["write", "write"], 
    "write" : []
}
```

- Server 응답
```json
{
    "message": "There should not be more than one process going from drop to write."
    "status": 400
}
```

---

### 최종 목적지가 여러개인 경우
```json
"task_list" : {
    "read" : ["drop"], 
    "drop" : ["write"],
    "write" : [],
    "drop": [],
    "read": []
}
```

- Server 응답
```json
{
    "message": "There should not be more than one final destination."
    "status": 400
}
```




<br />

## :: ISSUE
- JSON Response로 응답하지는 않고 메시지를 전달해 주고 있음.
- `TODO`: 따로 추가로 정의해주어 raise하는 방식으로 수정 필요

<br />